### PR TITLE
Reorganized the context menu and added separators

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,13 +264,13 @@ function addCommands(
 
   // Add items to the context menu
   app.contextMenu.addItem({
-    command: CommandIDs.copyContextMenu,
+    command: CommandIDs.cutContextMenu,
     selector: SELECTOR,
     rank: 0
   });
 
   app.contextMenu.addItem({
-    command: CommandIDs.cutContextMenu,
+    command: CommandIDs.copyContextMenu,
     selector: SELECTOR,
     rank: 0
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,30 +264,6 @@ function addCommands(
 
   // Add items to the context menu
   app.contextMenu.addItem({
-    command: CommandIDs.addRow,
-    selector: SELECTOR,
-    rank: 0
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.removeRow,
-    selector: SELECTOR,
-    rank: 0
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.addColumn,
-    selector: SELECTOR,
-    rank: 0
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.removeColumn,
-    selector: SELECTOR,
-    rank: 0
-  });
-
-  app.contextMenu.addItem({
     command: CommandIDs.copyContextMenu,
     selector: SELECTOR,
     rank: 0
@@ -301,6 +277,42 @@ function addCommands(
 
   app.contextMenu.addItem({
     command: CommandIDs.pasteContextMenu,
+    selector: SELECTOR,
+    rank: 0
+  });
+
+  app.contextMenu.addItem({
+    selector: SELECTOR,
+    rank: 0,
+    type: 'separator'
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.addRow,
+    selector: SELECTOR,
+    rank: 0
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.removeRow,
+    selector: SELECTOR,
+    rank: 0
+  });
+
+  app.contextMenu.addItem({
+    selector: SELECTOR,
+    rank: 0,
+    type: 'separator'
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.addColumn,
+    selector: SELECTOR,
+    rank: 0
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.removeColumn,
     selector: SELECTOR,
     rank: 0
   });
@@ -319,6 +331,14 @@ function addCommands(
     keys: ['Accel X'],
     selector: SELECTOR
   });
+
+  app.commands.addKeyBinding({
+    command: CommandIDs.pasteContextMenu,
+    args: {},
+    keys: ['Accel V'],
+    selector: SELECTOR
+  });
+
   app.commands.addKeyBinding({
     command: CommandIDs.undo,
     args: {},


### PR DESCRIPTION
# Description of the Pull Request
Reorganized the context menu so that the cut, copy, and paste are at the top of the context menu. The context menu is still being worked on to display different commands depending on where you click on the data table.

### Issue being fixed:
None

### Changes proposed:
- Moved cut, copy, paste commands above the add/ remove row/ column commands
- Added line separators to the context menu

