### PR TITLE
Grab cursor for row/columns headers appears based on current selection

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -40,13 +40,16 @@ export class RichMouseHandler extends BasicMouseHandler {
 
   cursorByRegion(): string {
     const hit = this._grid.hitTest(this._event.clientX, this._event.clientY);
+    // display the grab cursor if the row/column is in the curent selection
     switch (hit.region) {
-      case 'row-header': {
-        return 'grab';
-      }
-      case 'column-header': {
-        return 'grab';
-      }
+      case 'row-header':
+        return this._grid.selectionModel.isRowSelected(hit.row)
+          ? 'grab'
+          : 'default';
+      case 'column-header':
+        return this._grid.selectionModel.isColumnSelected(hit.column)
+          ? 'grab'
+          : 'default';
       default: {
         return 'default';
       }


### PR DESCRIPTION
# Grab cursor for row/column headers appears based on current selection

### Issue being fixed:
Fixes #135 

### Changes proposed:
- Grab cursor only appears if the row/column header is in the current selection
- Moving a row/column is only possible after it's selected