### PR TITLE
Clear contents functionality

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -22,7 +22,7 @@ export class RichMouseHandler extends BasicMouseHandler {
     return this._resizeSignal;
   }
 
-  get rightClickSignal(): Signal<this, Array<number>> {
+  get rightClickSignal(): Signal<this, DataGrid.HitTestResult> {
     return this._rightClickSignal;
   }
 
@@ -364,14 +364,13 @@ export class RichMouseHandler extends BasicMouseHandler {
   onContextMenu(grid: DataGrid, event: MouseEvent): void {
     const { clientX, clientY } = event;
     const hit = grid.hitTest(clientX, clientY);
-    const { row, column } = hit;
-    this._rightClickSignal.emit([row, column]);
+    this._rightClickSignal.emit(hit);
   }
   private _grid: DataGrid;
   private _event: MouseEvent;
   private _cursor: string | null;
   private _moveData: MoveData | null;
-  private _rightClickSignal = new Signal<this, Array<number>>(this);
+  private _rightClickSignal = new Signal<this, DataGrid.HitTestResult>(this);
   private _resizeSignal = new Signal<this, null>(this);
   private _selectionIndex: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,6 +364,12 @@ function addCommands(
     keys: ['Accel Shift Z'],
     selector: GLOBAL_SELECTOR
   });
+  app.commands.addKeyBinding({
+    command: CommandIDs.clearContents,
+    args: {},
+    keys: ['Backspace'],
+    selector: GLOBAL_SELECTOR
+  });
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,6 +290,14 @@ function addCommands(
     }
   });
 
+  commands.addCommand(CommandIDs.clearContents, {
+    label: 'Clear Contents',
+    execute: () => {
+      tracker.currentWidget &&
+        tracker.currentWidget.content.changeModelSignal.emit('clear-contents');
+    }
+  });
+
   // these commands are standard for every context menu
   const standardContextMenu = [
     'cutContextMenu',
@@ -304,21 +312,24 @@ function addCommands(
     'insertRowAbove',
     'insertRowBelow',
     'separator',
-    'removeRow'
+    'removeRow',
+    'clearContents'
   ];
   const columnHeaderContextMenu = [
     ...standardContextMenu,
     'insertColumnLeft',
     'insertColumnRight',
     'separator',
-    'removeColumn'
+    'removeColumn',
+    'clearContents'
   ];
   const rowHeaderContextMenu = [
     ...standardContextMenu,
     'insertRowAbove',
     'insertRowBelow',
     'separator',
-    'removeRow'
+    'removeRow',
+    'clearContents'
   ];
 
   // build the different context menus
@@ -365,7 +376,7 @@ function buildContextMenu(
   app: JupyterFrontEnd,
   commands: Array<string>,
   selector: string
-) {
+): void {
   // iterate over every command adding it to the context menu
   commands.forEach(
     (command: string): void => {
@@ -451,5 +462,6 @@ export const CommandIDs: { [key: string]: string } = {
   pasteToolbar: 'tde:paste-tb',
   undo: 'tde:undo',
   redo: 'tde:redo',
-  save: 'tde-save'
+  save: 'tde-save',
+  clearContents: 'tde-clear-contents'
 };

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { MutableDataModel, DataModel } from 'tde-datagrid';
+import { MutableDataModel, DataModel, SelectionModel } from 'tde-datagrid';
 import { DSVModel } from 'tde-csvviewer';
 import { Signal } from '@lumino/signaling';
 import { numberToCharacter } from './_helper';
@@ -668,6 +668,28 @@ export class EditableDSVModel extends MutableDataModel {
     };
     this.updateLitestore(change);
     this.handleEmits(change);
+  }
+
+  /**
+   * Clears the contents of the selected region
+   */
+  clearContents(
+    region: DataModel.CellRegion | 'void',
+    selection: SelectionModel.Selection
+  ): void {
+    if (region === 'void') {
+      return;
+    }
+    console.log(region, selection);
+    // const change: DataModel.ChangedArgs = {
+    //   type: 'cells-changed',
+    //   region: 'body',
+    //   row: row,
+    //   column: column,
+    //   rowSpan: 1,
+    //   columnSpan: 1
+    // };
+    // this.handleEmits(change)
   }
 
   /**

--- a/src/model.ts
+++ b/src/model.ts
@@ -688,42 +688,77 @@ export class EditableDSVModel extends MutableDataModel {
     let change: DataModel.ChangedArgs;
     //console.log(regionClicked, selection);
 
-    // clear contents of that column
-    if (regionClicked === 'column-header') {
-      // set params
-      row = 0;
-      column = columnClicked;
-      rowSpan = this.rowCount('body');
-      columnSpan = 1;
-      //console.log(columnSpan, row, column, rowSpan);
+    switch (regionClicked) {
+      // clear contents of that column
+      case 'column-header':
+        // set params
+        row = 0;
+        column = columnClicked;
+        rowSpan = this.rowCount('body');
+        columnSpan = 1;
 
-      //define change args
-      change = {
-        type: 'cells-changed',
-        region: 'body',
-        row: row,
-        column: column,
-        rowSpan: rowSpan,
-        columnSpan: columnSpan
-      };
+        //define change args
+        change = {
+          type: 'cells-changed',
+          region: 'body',
+          row: row,
+          column: column,
+          rowSpan: rowSpan,
+          columnSpan: columnSpan
+        };
 
-      this._litestore.beginTransaction();
-      // clear the contents of that cell
-      for (let i = 0; i < rowSpan; i++) {
-        this.setData('body', i, column, '', false);
-      }
-      // console.log(model.rawData);
-      this._litestore.updateRecord(
-        {
-          schema: DATAMODEL_SCHEMA,
-          record: RECORD_ID
-        },
-        {
-          modelData: model.rawData,
-          change: change
+        this._litestore.beginTransaction();
+        // iterate through column to clear contents
+        for (let i = 0; i < rowSpan; i++) {
+          this.setData('body', i, column, '', false);
         }
-      );
-      this._litestore.endTransaction();
+        this._litestore.updateRecord(
+          {
+            schema: DATAMODEL_SCHEMA,
+            record: RECORD_ID
+          },
+          {
+            modelData: model.rawData,
+            change: change
+          }
+        );
+        this._litestore.endTransaction();
+        break;
+      // clear contents of that row
+      case 'row-header':
+        // set params
+        row = rowClicked;
+        column = 0;
+        rowSpan = 1;
+        columnSpan = this.columnCount('body');
+
+        //define change args
+        change = {
+          type: 'cells-changed',
+          region: 'body',
+          row: row,
+          column: column,
+          rowSpan: rowSpan,
+          columnSpan: columnSpan
+        };
+
+        this._litestore.beginTransaction();
+        // iterate through row to clear contents
+        for (let i = 0; i < columnSpan; i++) {
+          this.setData('body', row, i, '', false);
+        }
+        this._litestore.updateRecord(
+          {
+            schema: DATAMODEL_SCHEMA,
+            record: RECORD_ID
+          },
+          {
+            modelData: model.rawData,
+            change: change
+          }
+        );
+        this._litestore.endTransaction();
+        break;
     }
     //console.log(change);
   }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -14,7 +14,8 @@ import {
   BasicSelectionModel,
   DataGrid,
   TextRenderer,
-  SelectionModel
+  SelectionModel,
+  DataModel
 } from 'tde-datagrid';
 import { Message } from '@lumino/messaging';
 import { PanelLayout, Widget } from '@lumino/widgets';
@@ -412,6 +413,10 @@ export class EditableCSVViewer extends Widget {
         this.dataModel.paste({ row: r1, column: c1 });
         break;
       }
+      case 'clear-contents': {
+        this.dataModel.clearContents(this._region, this.getSelectedRange());
+        break;
+      }
       case 'undo': {
         const { change } = this.dataModel.litestore.getRecord({
           schema: DATAMODEL_SCHEMA,
@@ -467,7 +472,7 @@ export class EditableCSVViewer extends Widget {
     this._grid.selectionModel.select(select);
   }
 
-  protected getSelectedRange(): any {
+  protected getSelectedRange(): SelectionModel.Selection {
     const selections = toArray(this._grid.selectionModel.selections());
     if (selections.length === 0) {
       return;
@@ -490,9 +495,11 @@ export class EditableCSVViewer extends Widget {
 
   private _onRightClick(
     emitter: RichMouseHandler,
-    coords: Array<number>
+    hit: DataGrid.HitTestResult
   ): void {
-    [this._row, this._column] = coords;
+    this._region = hit.region;
+    this._row = hit.row;
+    this._column = hit.column;
   }
 
   private _onResize(emitter: RichMouseHandler) {
@@ -506,6 +513,7 @@ export class EditableCSVViewer extends Widget {
     this._rowHeader.style.height = `${this._grid.viewportHeight}px`;
   }
 
+  private _region: DataModel.CellRegion | 'void';
   private _row: number;
   private _column: number;
   private _context: DocumentRegistry.Context;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -509,7 +509,7 @@ export class EditableCSVViewer extends Widget {
     this._column = hit.column;
   }
 
-  private _onResize(emitter: RichMouseHandler) {
+  private _onResize(emitter: RichMouseHandler): void {
     this._background.style.width = `${this._grid.viewportWidth}px`;
     this._background.style.height = `${this._grid.viewportHeight}px`;
     this._columnHeader.style.left = `${this._grid.headerWidth}px`;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -414,7 +414,12 @@ export class EditableCSVViewer extends Widget {
         break;
       }
       case 'clear-contents': {
-        this.dataModel.clearContents(this._region, this.getSelectedRange());
+        this.dataModel.clearContents(
+          this._region,
+          this._row,
+          this._column,
+          this.getSelectedRange()
+        );
         break;
       }
       case 'undo': {
@@ -497,7 +502,9 @@ export class EditableCSVViewer extends Widget {
     emitter: RichMouseHandler,
     hit: DataGrid.HitTestResult
   ): void {
-    this._region = hit.region;
+    if (hit.region !== 'void') {
+      this._region = hit.region;
+    }
     this._row = hit.row;
     this._column = hit.column;
   }
@@ -513,7 +520,7 @@ export class EditableCSVViewer extends Widget {
     this._rowHeader.style.height = `${this._grid.viewportHeight}px`;
   }
 
-  private _region: DataModel.CellRegion | 'void';
+  private _region: DataModel.CellRegion;
   private _row: number;
   private _column: number;
   private _context: DocumentRegistry.Context;

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -236,6 +236,11 @@ describe('table editing functions', () => {
       const expected = ['A,B,C', '1,2,3', ',,', '7,8,9'].join('\n');
       expect(model.dsvModel.rawData).toBe(expected);
     });
+    it('clear contents of a selection', () => {
+      model.clearContents('body', 1, 0, { r1: 1, r2: 0, c1: 0, c2: 1 });
+      const expected = ['A,B,C', ',,3', ',,6', '7,8,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expected);
+    });
   });
   describe('undo function', () => {
     it('tries to undo when nothing can be undone', () => {
@@ -329,6 +334,16 @@ describe('table editing functions', () => {
     });
     it('undo clear contents for a row', () => {
       model.clearContents('row-header', 0, 2, undefined);
+      change = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      }).change;
+      model.undo(change);
+      const expectedData = ['A,B,C', '1,2,3', 'abc,5,6', '7,8,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expectedData);
+    });
+    it('undo clear contents for a selection', () => {
+      model.clearContents('body', 1, 0, { r1: 1, r2: 0, c1: 0, c2: 1 });
       change = model.litestore.getRecord({
         schema: DATAMODEL_SCHEMA,
         record: RECORD_ID
@@ -495,6 +510,22 @@ describe('table editing functions', () => {
       });
       model.redo(change, modelData);
       const expected = ['A,B,C', '1,2,3', ',,', '7,8,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expected);
+    });
+    it('redo clear contents for a selection', () => {
+      model.clearContents('body', 1, 0, { r1: 1, r2: 0, c1: 0, c2: 1 });
+      const oldChange = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      }).change;
+      model.undo(oldChange);
+      model.litestore.redo();
+      const { change, modelData } = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      });
+      model.redo(change, modelData);
+      const expected = ['A,B,C', ',,3', ',,6', '7,8,9'].join('\n');
       expect(model.dsvModel.rawData).toBe(expected);
     });
   });

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -225,6 +225,13 @@ describe('table editing functions', () => {
       expect(model.dsvModel.rawData).toBe(expectedData);
     });
   });
+  describe('clear contents function', () => {
+    it('clear contents of a column', () => {
+      model.clearContents('column-header', 0, 1, undefined);
+      const expected = ['A,B,C', '1,,3', 'abc,,6', '7,,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expected);
+    });
+  });
   describe('undo function', () => {
     it('tries to undo when nothing can be undone', () => {
       change = model.litestore.getRecord({
@@ -297,6 +304,16 @@ describe('table editing functions', () => {
     });
     it('undo move a column', () => {
       model.moveColumn(0, 2);
+      change = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      }).change;
+      model.undo(change);
+      const expectedData = ['A,B,C', '1,2,3', 'abc,5,6', '7,8,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expectedData);
+    });
+    it('undo clear contents for a column', () => {
+      model.clearContents('column-header', 0, 1, undefined);
       change = model.litestore.getRecord({
         schema: DATAMODEL_SCHEMA,
         record: RECORD_ID
@@ -432,6 +449,22 @@ describe('table editing functions', () => {
       model.redo(change, modelData);
       const expectedData = ['A,B,C', '1,3,2', 'abc,6,5', '7,9,8'].join('\n');
       expect(model.dsvModel.rawData).toBe(expectedData);
+    });
+    it('redo clear contents for a column', () => {
+      model.clearContents('column-header', 0, 1, undefined);
+      const oldChange = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      }).change;
+      model.undo(oldChange);
+      model.litestore.redo();
+      const { change, modelData } = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      });
+      model.redo(change, modelData);
+      const expected = ['A,B,C', '1,,3', 'abc,,6', '7,,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expected);
     });
   });
 });

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -231,6 +231,11 @@ describe('table editing functions', () => {
       const expected = ['A,B,C', '1,,3', 'abc,,6', '7,,9'].join('\n');
       expect(model.dsvModel.rawData).toBe(expected);
     });
+    it('clear contents of a row', () => {
+      model.clearContents('row-header', 1, 0, undefined);
+      const expected = ['A,B,C', '1,2,3', ',,', '7,8,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expected);
+    });
   });
   describe('undo function', () => {
     it('tries to undo when nothing can be undone', () => {
@@ -314,6 +319,16 @@ describe('table editing functions', () => {
     });
     it('undo clear contents for a column', () => {
       model.clearContents('column-header', 0, 1, undefined);
+      change = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      }).change;
+      model.undo(change);
+      const expectedData = ['A,B,C', '1,2,3', 'abc,5,6', '7,8,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expectedData);
+    });
+    it('undo clear contents for a row', () => {
+      model.clearContents('row-header', 0, 2, undefined);
       change = model.litestore.getRecord({
         schema: DATAMODEL_SCHEMA,
         record: RECORD_ID
@@ -464,6 +479,22 @@ describe('table editing functions', () => {
       });
       model.redo(change, modelData);
       const expected = ['A,B,C', '1,,3', 'abc,,6', '7,,9'].join('\n');
+      expect(model.dsvModel.rawData).toBe(expected);
+    });
+    it('redo clear contents for a row', () => {
+      model.clearContents('row-header', 1, 0, undefined);
+      const oldChange = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      }).change;
+      model.undo(oldChange);
+      model.litestore.redo();
+      const { change, modelData } = model.litestore.getRecord({
+        schema: DATAMODEL_SCHEMA,
+        record: RECORD_ID
+      });
+      model.redo(change, modelData);
+      const expected = ['A,B,C', '1,2,3', ',,', '7,8,9'].join('\n');
       expect(model.dsvModel.rawData).toBe(expected);
     });
   });


### PR DESCRIPTION
# Clear contents functionality

### Issue being fixed:
Fixes #128 

### Changes proposed:
- Modified rightClick signal to send the results of the `HitTest`
- Clear contents functionality for rows, columns, and selections (undo/redo included)
- Clear contents command added to the context menu
- `Backspace` keybinding for clear contents
- Unit tests for clear contents
