### PR TITLE
Color changes to cell selection, cell highlight border, and dark theme column header 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -484,7 +484,11 @@ namespace Private {
     backgroundColor: 'white',
     headerBackgroundColor: '#EEEEEE',
     gridLineColor: 'rgba(20, 20, 20, 0.15)',
-    headerGridLineColor: 'rgba(20, 20, 20, 0.25)'
+    headerGridLineColor: 'rgba(20, 20, 20, 0.25)',
+    selectionBorderColor: 'rgb(33,150,243)',
+    cursorBorderColor: 'rgb(33,150,243)', //selected cell border color
+    headerSelectionBorderColor: 'rgb(33,150,243, 0)' //made transparent
+
     //rowBackgroundColor: i => (i % 2 === 0 ? '#F5F5F5' : 'white')
   };
 
@@ -497,7 +501,8 @@ namespace Private {
     backgroundColor: '#111111',
     headerBackgroundColor: '#424242',
     gridLineColor: 'rgba(235, 235, 235, 0.15)',
-    headerGridLineColor: 'rgba(235, 235, 235, 0.25)'
+    headerGridLineColor: 'rgba(235, 235, 235, 0.25)',
+    headerSelectionFillColor: 'rgba(20, 20, 20, 0.25)'
     //rowBackgroundColor: i => (i % 2 === 0 ? '#212121' : '#111111')
   };
 

--- a/style/index.css
+++ b/style/index.css
@@ -5,7 +5,8 @@
 /*border of a cell*/
 .lm-DataGrid-cellEditorContainer {
   border: 2px solid #2196f3;
-  box-shadow: var(--jp-cell-editor-box-shadow);
+  box-shadow: var(--jp-elevation-z1);
+  /*box-shadow: var(--jp-cell-editor-box-shadow); - not noticeable*/
 }
 
 /*surrounding of the cell when double clicked*/
@@ -53,7 +54,7 @@
 
 .lm-DataGrid-select-line {
   border: none;
-  background-color: #2196F3;
+  background-color: #2196f3;
 }
 
 .jp-row-header {
@@ -61,6 +62,7 @@
 }
 .jp-column-header {
   border: none;
+  color: var(--jp-layout-color3);
 }
 
 .jp-background {


### PR DESCRIPTION
### Description of the Pull Request
Styling changes have been made. In light mode, there's no longer a blue border next to the column/ row names when a cell is selected. The border of the cell selected and the highlighting border is the same color now. Also, added elevation to the cell when selected to be edited. In dark mode, the column/ row header is slightly darker when a cell is selected. 

### Issue being fixed:
None

### Changes proposed:
- Light mode: removed blue border next to columns/ rows when a cell is selected
- Light mode: added elevation when a cell is selected to be edited
- Light mode: consistent color between selected cell border and highlighting border
- Dark mode: darker column/ row header when a cell is selected
