### PR TITLE
Selection UX for insert below, insert right, move row/column

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -367,6 +367,9 @@ export class EditableCSVViewer extends Widget {
    * @param type
    */
   private _changeModel(emitter: EditableCSVViewer, type: string): void {
+    const selectionModel = this._grid.selectionModel;
+    const { r1, r2, c1, c2 } = selectionModel.currentSelection();
+
     switch (type) {
       case 'insert-row-above': {
         this.dataModel.addRow(this._row);
@@ -374,6 +377,17 @@ export class EditableCSVViewer extends Widget {
       }
       case 'insert-row-below': {
         this.dataModel.addRow(this._row + 1);
+
+        // move the selection down a row to account for the new row being inserted
+        selectionModel.select({
+          r1: r1 + 1,
+          r2: r2 + 1,
+          c1,
+          c2,
+          cursorRow: r1,
+          cursorColumn: c1,
+          clear: 'all'
+        });
         break;
       }
       case 'insert-column-left': {
@@ -382,6 +396,17 @@ export class EditableCSVViewer extends Widget {
       }
       case 'insert-column-right': {
         this.dataModel.addColumn(this._column + 1);
+
+        // move the selection down a row to account for the new column being inserted
+        selectionModel.select({
+          r1,
+          r2,
+          c1: c1 + 1,
+          c2: c2 + 1,
+          cursorRow: r1,
+          cursorColumn: c1,
+          clear: 'all'
+        });
         break;
       }
       case 'remove-row': {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -368,7 +368,16 @@ export class EditableCSVViewer extends Widget {
    */
   private _changeModel(emitter: EditableCSVViewer, type: string): void {
     const selectionModel = this._grid.selectionModel;
-    const { r1, r2, c1, c2 } = selectionModel.currentSelection();
+    const selection = selectionModel.currentSelection();
+    let r1, r2, c1, c2: number;
+
+    // grab selection if it exists
+    if (selection) {
+      r1 = selection.r1;
+      r2 = selection.r2;
+      c1 = selection.c1;
+      c2 = selection.c2;
+    }
 
     switch (type) {
       case 'insert-row-above': {
@@ -378,6 +387,9 @@ export class EditableCSVViewer extends Widget {
       case 'insert-row-below': {
         this.dataModel.addRow(this._row + 1);
 
+        if (!selection) {
+          return;
+        }
         // move the selection down a row to account for the new row being inserted
         selectionModel.select({
           r1: r1 + 1,
@@ -397,6 +409,9 @@ export class EditableCSVViewer extends Widget {
       case 'insert-column-right': {
         this.dataModel.addColumn(this._column + 1);
 
+        if (!selection) {
+          return;
+        }
         // move the selection down a row to account for the new column being inserted
         selectionModel.select({
           r1,


### PR DESCRIPTION
# Selection UX for insert below, insert right, move row/column
### Issue being fixed:
Fixes #147  
Fixes #148 

### Changes proposed:
- Inserting a row below and inserting a column to the right selects the right row/column
- Moving a row/column selects the one that was moved

Creates an issue when trying to undo insert below/right #152 