### PR TITLE
Litestore refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ### Manipulate your tabular data responsively and effectively within JupyterLab.
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupytercalpoly/jupyterlab-tabular-data-editor/32b9c33a8596e62022b1b716f07d72bb78ed7fb7?urlpath=lab) ![Github Actions Status](https://github.com/jupytercalpoly/jupyterlab-tabular-data-editor/workflows/Build/badge.svg)
+[![Binder](https://mybinder.org/badge_logo.svg)](ttps://mybinder.org/v2/gh/jupytercalpoly/jupyterlab-tabular-data-editor/master?urlpath=lab) ![Github Actions Status](https://github.com/jupytercalpoly/jupyterlab-tabular-data-editor/workflows/Build/badge.svg)
 
 ### EXPERIMENTAL: This extension is still in alpha. The API is subject to frequent changes.
+
 ### Please contact [Kalen](https://github.com/kgoo124), [Logan](https://github.com/lmcnichols), or [Ryan](https://github.com/ryuntalan) if you would like to contribute!
 
 Try our extension [here](https://mybinder.org/v2/gh/jupytercalpoly/jupyterlab-tabular-data-editor/master?urlpath=lab)!

--- a/src/litestore.ts
+++ b/src/litestore.ts
@@ -31,6 +31,20 @@ export class TransactionStore {
   }
 
   /**
+   * Returns the current undo stack
+   */
+  get undoStack(): string[] {
+    return this._undoStack;
+  }
+
+  /**
+   * Returns the current redo stack
+   */
+  get redoStack(): string[] {
+    return this._redoStack;
+  }
+
+  /**
    * Add a transaction to the patch store.
    *
    * @param - the transaction to add to the store.
@@ -361,6 +375,10 @@ export class Litestore implements IDisposable, IIterable<Table<Schema>> {
    */
   get cemetery(): { [id: string]: number } {
     return this._transactionStore.cemetery;
+  }
+
+  get transactionStore(): TransactionStore {
+    return this._transactionStore;
   }
 
   /**

--- a/src/searchprovider.ts
+++ b/src/searchprovider.ts
@@ -5,7 +5,7 @@ import { EditableCSVViewer } from './widget';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import { Signal, ISignal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
-import { DATAMODEL_SCHEMA, RECORD_ID } from './model';
+import { DataModel } from 'tde-datagrid';
 
 // The type for which canSearchFor returns true
 export type CSVDocumentWidget = DocumentWidget<EditableCSVViewer>;
@@ -146,8 +146,7 @@ export class CSVSearchProvider implements ISearchProvider<CSVDocumentWidget> {
    * @returns A promise that resolves once the action has completed.
    */
   async replaceAllMatches(newText: string): Promise<boolean> {
-    const model = this._target.content.dataModel.dsvModel;
-    const litestore = this._target.content.dataModel.litestore;
+    const litestore = this._target.content.litestore;
     const searchService = this._target.content.searchService;
     const startRow = searchService.currentMatch.line;
     const startColumn = searchService.currentMatch.column;
@@ -164,25 +163,17 @@ export class CSVSearchProvider implements ISearchProvider<CSVDocumentWidget> {
       }
       this.replaceCurrentMatch(newText, false);
     }
-    litestore.updateRecord(
-      {
-        schema: DATAMODEL_SCHEMA,
-        record: RECORD_ID
-      },
-      {
-        modelData: model.rawData,
-        modelHeader: model.header,
-        change: {
-          type: 'cells-changed',
-          region: 'body',
-          // the range of cells being edited
-          row: startRow,
-          column: startColumn,
-          rowSpan: endRow - startRow,
-          columnSpan: endColumn - startColumn
-        }
-      }
-    );
+
+    const change: DataModel.ChangedArgs = {
+      type: 'cells-changed',
+      region: 'body',
+      // the range of cells being edited
+      row: startRow,
+      column: startColumn,
+      rowSpan: endRow - startRow,
+      columnSpan: endColumn - startColumn
+    };
+    this._target.content.updateLitestore(change);
     litestore.endTransaction();
     return true;
   }


### PR DESCRIPTION
# Litestore refactor

### Issue being fixed:
Closes #153  

### Changes proposed:
- Getters for `undoStack` and `redoStack` in the `TransactionStore` in the `Litestore`
- `Litestore` moved from `DataModel` into `EditableCSVViewer`
- `onChangedSignal` nows emits a couple arguments: `data`, `change`, and a boolean `useLitestore`
- `_updateModel` now handles `Litestore` transaction
   - for multiple edits like `replace all` and `clear contents`, their respective functions handle the transaction
- Update binder badge link
