### PR TITLE
Right-click selection fixes

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -394,6 +394,16 @@ export class RichMouseHandler extends BasicMouseHandler {
     const { clientX, clientY } = event;
     const hit = grid.hitTest(clientX, clientY);
     this._rightClickSignal.emit(hit);
+
+    // if the right click is in the current selection, return
+    if (
+      this._grid.selectionModel.isRowSelected(hit.row) &&
+      this._grid.selectionModel.isColumnSelected(hit.column)
+    ) {
+      return;
+    }
+    // otherwise select the respective row/column/cell
+    super.onMouseDown(grid, event);
   }
   private _grid: DataGrid;
   private _event: MouseEvent;


### PR DESCRIPTION
# Right-click selection fixes

### Issue being fixed:
Fixes #154 
Fixes #160 

### Changes proposed:
- Right-clicking within selection keeps the same thing selected
- Right-clicking outside of the selection selects that row/column/cells
