### PR TITLE
Selection UX for Undo/Redo

### DIFF
--- a/demo/customer-recipes.csv
+++ b/demo/customer-recipes.csv
@@ -1,31 +1,20 @@
-Customer Code,First Name,Last Name,Job Title,Recipe,Recipe Score,Email,Location,Location
-JL7321,Timothy,George,Lead UX/UI Designer,Snozzberry Surprise,10,timsfilez@gmail.com,California,California
-JL9123,Elliot,King,Data Scientist,Leftover Burrito,4,elliotking@gmail.com,New York,New York
-JL8152,Noel,Hall,UX Researcher,Eggs in a Nest,7,noelhall@gmail.com,Texas,Texas
-JL8315,Robert,Wright,Data Scientist,Loaded Tater Tots,9,robertwright@gmail.com,Washington,Washington
-JL0917,Zachary,Sailer,Lead Software Engineer,Cinnamon Rolls,1000,zachsailer@gmail.com,California,California
-JL8753,Addison,Lee,Senior Data Scientist,Green Onion Pancakes,8,addisonlee@gmail.com,New York,New York
-JL1032,Jay,Ahn,Software Engineer Intern,Cabbage Egg Rice Bowl,10,aju960219@gmail.com,California,California
-JL5362,Cameron,Toy,Software Engineer Intern,Pad Krapow,10,cameron.toy.00@gmail.com,California,California
-JL7163,Ai-Vy,Dang,UX/UI Design Intern,Avocado Toast,10,aivydang@gmail.com,California,California
-JL3124,Logan,McNichols,Software Engineer Intern,Sweet Potatoe Bytes,10,loganamcnichols@gmail.com,California,California
-JL8715,Abed,Glover,UX Researcher,Buttered Noodles,7,abed.glover@gmail.com,Florida,Florida
-JL0127,Ana,Ruvalcaba,Director Project Jupyter,Best Greek Yogurt Bowl EVERRR,10,ruv7.ana@gmail.com,California,California
-JL8761,Julia,Huynh,UX/UI Design Intern,Easy Rice and Eggs,10,charlizeh@gmail.com,California,California
-JL7152,Kalen,Goo,Software Engineer Intern,Poke Bowl,10,ktwmgoo@gmail.com,Hawaii,Hawaii
-JL3245,Kiran,Pinnipati,Software Engineer Intern,Easy Vegetable Omelette,10,kpinnipati@gmail.com,California,California
-JL8612,Jessica,Xu,Software Engineer Intern,Bluberry Nojito,10,jxu22@gmail.com,California,California
-JL2401,Ryan,Untalan,UX/UI Design Intern,Air Fried Potstickers,10,untalan.ryan@gmail.com,California,California
-JL8018,Avery,Malone,Data Scientist,Peanut Butter Protein Shake,5,amalone@gmail.com,Oregon,Oregon
-JL3761,Taylor,Zhou,Sales Manager,Fluffy Pancakes,8,taylor_zhou@gmail.com,Hawaii,Hawaii
-JL4157,Sydney,Jones,UX Researcher,Turkey Club Wrap,6,sydneyjones@gmail.com,Washington,Washington
-JL4159,Oakley,Smith,Software Engineer Intern,Chicken Salad,7,oakleysmith@gmail.com,California,California
-JL3463,Skylar,Lennon,Software Engineer Intern,Pesto Pasta,8,skylarlennon@gmail.com,California,California
-JL7457,Parker,Holmes,Data Scientist,Lemon Tart,8,parkerholmes@gmail.com,California,California
-JL9101,Brooklyn,Serrano,Data Scientist,Chocolate Chip Cookies,7,brook.serr@gmail.com,Oregon,Oregon
-JL0812,Kyler,Flores,Sales Specialist,Homemade Nachos,6,ky.flo.ren@gmail.com,Hawaii,Hawaii
-JL9712,Denver,Anderson,UX Researcher,Fruit Salad,5,denver.and@gmail.com,Washington,Washington
-JL6541,Jules,Young,Marketing Specialist,Onigiri,9,julesyoung@gmail.com,California,California
-JL9012,Blake,Ochoa,Data Scientist,Mac and Cheese,7,blake.o@gmail.com,California,California
-JL1364,Drew,Donaldson,Marketing Specialist,Cheese Burger,6,drew.donaldson@gmail.com,California,California
-JL7813,Robin,Lee,Data Scientist,Acai Bowl,8,robinlee@gmail.com,California,California
+Customer Code,First Name,Last Name,Email,Job Title,Recipe,Recipe Score,Location
+JL9123,Elliot,King,elliotking@gmail.com,Data Scientist,Leftover Burrito,4,New York
+JL8152,Noel,Hall,noelhall@gmail.com,UX Researcher,Eggs in a Nest,7,Texas
+JL8315,Robert,Wright,robertwright@gmail.com,Data Scientist,Loaded Tater Tots,9,Washington
+JL8753,Addison,Lee,addisonlee@gmail.com,Senior Data Scientist,Green Onion Pancakes,8,New York
+JL7123,Bobby,Gray,bobbygray@gmail.com,Software Engineer,Lamb Chops with Mint Jelly,9,California
+JL0961,Gordon,Hamsay,gordonhamsay@gmail.com,UX/UI Designer,Beef Wellington,10,California
+JL7812,Guy,Mustang,guymustang@gmail.com,Sales Manager,Flavortown French Toast,10,California
+JL8715,Abed,Glover,abed.glover@gmail.com,UX Researcher,Buttered Noodles,7,Florida
+JL8018,Avery,Malone,amalone@gmail.com,Data Scientist,Peanut Butter Protein Shake,5,Oregon
+JL3761,Taylor,Zhou,taylor_zhou@gmail.com,Sales Manager,Fluffy Pancakes,8,Hawaii
+JL4157,Sydney,Jones,sydneyjones@gmail.com,UX Researcher,Turkey Club Wrap,6,Washington
+JL3463,Skylar,Lennon,skylarlennon@gmail.com,Software Engineers,Pesto Pasta,8,California
+JL7457,Parker,Holmes,parkerholmes@gmail.com,Data Scientist,Lemon Tart,8,California
+JL9101,Brooklyn,Serrano,brook.serr@gmail.com,Data Scientist,Chocolate Chip Cookies,7,Oregon
+JL0812,Kyler,Flores,ky.flo.ren@gmail.com,Sales Specialist,Homemade Nachos,6,Hawaii
+JL9712,Denver,Anderson,denver.and@gmail.com,UX Researcher,Fruit Salad,5,Washington
+JL9012,Blake,Ochoa,blake.o@gmail.com,Data Scientist,Mac and Cheese,7,California
+JL1364,Drew,Donaldson,drew.donaldson@gmail.com,Marketing Specialist,Cheese Burger,6,California
+JL7813,Robin,Lee,robinlee@gmail.com,Data Scientist,Acai Bowl,8,California

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -394,6 +394,16 @@ export class RichMouseHandler extends BasicMouseHandler {
     const { clientX, clientY } = event;
     const hit = grid.hitTest(clientX, clientY);
     this._rightClickSignal.emit(hit);
+
+    // if the right click is in the current selection, return
+    if (
+      this._grid.selectionModel.isRowSelected(hit.row) &&
+      this._grid.selectionModel.isColumnSelected(hit.column)
+    ) {
+      return;
+    }
+    // otherwise select the respective row/column/cell
+    super.onMouseDown(grid, event);
   }
   private _grid: DataGrid;
   private _event: MouseEvent;

--- a/src/searchprovider.ts
+++ b/src/searchprovider.ts
@@ -173,7 +173,7 @@ export class CSVSearchProvider implements ISearchProvider<CSVDocumentWidget> {
       rowSpan: endRow - startRow,
       columnSpan: endColumn - startColumn
     };
-    this._target.content.updateLitestore(change);
+    this._target.content.updateLitestore('replace-all', change);
     litestore.endTransaction();
     return true;
   }


### PR DESCRIPTION
# Selection UX for Undo/Redo

### Issue being fixed:
Fixes #152 

### Changes proposed:
- Right-click always selects something unless click is inside a current selection
- Added a `type` field to the `Litestore` which keeps track of the `type` specific to our `EditableDSVModel`, not the `DataGrid`
- On redo for `insert-row-below`, `insert-column-right`, `rows-moved`, and `columns-moved`, the row/column/cell selected is now corrected