### PR TITLE
Shadow/line fixes when moving + handler.ts refactoring

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -278,31 +278,20 @@ export class RichMouseHandler extends BasicMouseHandler {
       rightBound =
         left + this._grid.headerWidth + this._grid.pageWidth - (c2 - c1);
     } else if (region === 'row-header') {
-      lowerBound =
-        top +
-        Math.min(
-          this._grid.pageHeight - (r2 - r1),
-          this._grid.bodyHeight + this._grid.headerHeight - (r2 - r1)
-        );
-      upperBound = top + this._grid.headerHeight;
+      lowerBound = top + this._grid.headerHeight;
+      upperBound =
+        top + this._grid.headerHeight + this._grid.pageHeight - (r2 - r1);
       leftBound = rightBound = c1;
-    }
-
-    if (
-      event.clientX < leftBound ||
-      event.clientX > rightBound // ||
-      // event.clientY < lowerBound ||
-      // event.clientY > upperBound
-    ) {
-      console.log(lowerBound, upperBound);
-      return;
     }
 
     // see if we have crossed the boundary to a neighboring row/column
     switch (region) {
       case 'column-header': {
-        // bail early if we are still within the bounds
-        if (c1 < event.clientX && event.clientX < c2) {
+        // bail early if we are still within the bounds or outside of the grid viewport
+        if (
+          (c1 < event.clientX && event.clientX < c2) ||
+          (event.clientX < leftBound || event.clientX > rightBound)
+        ) {
           return;
         } else if (event.clientX < c1) {
           // we are at the previous column, get the new region
@@ -326,8 +315,11 @@ export class RichMouseHandler extends BasicMouseHandler {
         break;
       }
       case 'row-header': {
-        // bail early if we are still within the bounds
-        if (r1 < event.clientY && event.clientY < r2) {
+        // bail early if we are still within the bounds or outside of the grid viewport
+        if (
+          (r1 < event.clientY && event.clientY < r2) ||
+          (event.clientY < lowerBound || event.clientY > upperBound)
+        ) {
           return;
         } else if (event.clientY < r1) {
           // we are at the previous row, get the new region
@@ -388,7 +380,7 @@ export class RichMouseHandler extends BasicMouseHandler {
         });
       } else if (this._moveData.region === 'row-header') {
         const startRow = this._moveData.row;
-        const endRow = grid.rowAt('body', vy);
+        const endRow = this._selectionIndex;
         model.moveRow(startRow, endRow);
 
         // select the row that was just moved

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -106,7 +106,6 @@ export class RichMouseHandler extends BasicMouseHandler {
     const { left, top } = this._grid.viewport.node.getBoundingClientRect();
 
     // get the bounds for dragging
-
     let lowerBound: number;
     let upperBound: number;
     let rightBound: number;
@@ -255,7 +254,7 @@ export class RichMouseHandler extends BasicMouseHandler {
    * @param event
    */
   updateLinePos(grid: DataGrid, event: MouseEvent): void {
-    // find the region we originall clicked on.
+    // find the region we originally clicked on.
     const { region } = this._moveData;
 
     // initialize the variables for the the rectangular column/row region
@@ -264,6 +263,40 @@ export class RichMouseHandler extends BasicMouseHandler {
       this._selectionIndex,
       this._selectionIndex
     );
+
+    // get the left and top offsets of the grid viewport
+    const { left, top } = this._grid.viewport.node.getBoundingClientRect();
+
+    // get the bounds for dragging
+    let lowerBound: number;
+    let upperBound: number;
+    let rightBound: number;
+    let leftBound: number;
+    if (region === 'column-header') {
+      lowerBound = upperBound = r1;
+      leftBound = left + this._grid.headerWidth;
+      rightBound =
+        left + this._grid.headerWidth + this._grid.pageWidth - (c2 - c1);
+    } else if (region === 'row-header') {
+      lowerBound =
+        top +
+        Math.min(
+          this._grid.pageHeight - (r2 - r1),
+          this._grid.bodyHeight + this._grid.headerHeight - (r2 - r1)
+        );
+      upperBound = top + this._grid.headerHeight;
+      leftBound = rightBound = c1;
+    }
+
+    if (
+      event.clientX < leftBound ||
+      event.clientX > rightBound // ||
+      // event.clientY < lowerBound ||
+      // event.clientY > upperBound
+    ) {
+      console.log(lowerBound, upperBound);
+      return;
+    }
 
     // see if we have crossed the boundary to a neighboring row/column
     switch (region) {
@@ -341,7 +374,7 @@ export class RichMouseHandler extends BasicMouseHandler {
 
       if (this._moveData.region === 'column-header') {
         const startColumn = this._moveData.column;
-        const endColumn = grid.columnAt('body', vx);
+        const endColumn = this._selectionIndex;
         model.moveColumn(startColumn, endColumn);
         // select the row that was just moved
         selectionModel.select({

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -104,16 +104,20 @@ export class RichMouseHandler extends BasicMouseHandler {
     }
   }
 
+  /**
+   * @override
+   * @param grid
+   * @param event
+   */
   onMouseHover(grid: DataGrid, event: MouseEvent): void {
     this._event = event;
     super.onMouseHover(grid, event);
   }
 
   /**
+   * @override
    * Handle the mouse down event for the data grid.
-   *
    * @param grid - The data grid of interest.
-   *
    * @param event - The mouse down event of interest.
    */
   onMouseDown(grid: DataGrid, event: MouseEvent): void {
@@ -126,6 +130,9 @@ export class RichMouseHandler extends BasicMouseHandler {
     return;
   }
 
+  /**
+   * @override
+   */
   release(): void {
     if (this._moveData) {
       this._moveData.override.dispose();
@@ -134,6 +141,9 @@ export class RichMouseHandler extends BasicMouseHandler {
     super.release();
   }
 
+  /**
+   * Creates the shadow/line on the row/column that was grabbed
+   */
   handleGrabbing(): void {
     const hit = this._grid.hitTest(this._event.clientX, this._event.clientY);
     const { region, row, column } = hit;
@@ -253,10 +263,9 @@ export class RichMouseHandler extends BasicMouseHandler {
   }
 
   /**
+   * @override
    * Handle the mouse move event for the data grid.
-   *
    * @param grid - The data grid of interest.
-   *
    * @param event - The mouse move event of interest.
    */
   onMouseMove(grid: DataGrid, event: MouseEvent): void {
@@ -362,7 +371,7 @@ export class RichMouseHandler extends BasicMouseHandler {
   }
 
   /**
-   *
+   * @override
    * @param grid
    * @param event
    */
@@ -420,9 +429,7 @@ export class RichMouseHandler extends BasicMouseHandler {
 
   /**
    * Handle the context menu event for the data grid.
-   *
    * @param grid - The data grid of interest.
-   *
    * @param event - The context menu event of interest.
    */
   onContextMenu(grid: DataGrid, event: MouseEvent): void {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -6,7 +6,7 @@ import { MimeData } from '@lumino/coreutils';
 const SHADOW = 'lm-DataGrid-select-shadow';
 const LINE = 'lm-DataGrid-select-line';
 
-function createRectange(height: number, width: number): HTMLElement {
+function createRectangle(height: number, width: number): HTMLElement {
   return VirtualDOM.realize(
     h.div({
       className: SHADOW,
@@ -45,7 +45,9 @@ export function renderSelection(
   const mouseOffsetX = x - c1;
   const mouseOffsetY = y - r1;
   const target =
-    type === 'line' ? createLine(height, width) : createRectange(height, width);
+    type === 'line'
+      ? createLine(height, width)
+      : createRectangle(height, width);
   const dragSelection = new BoundedDrag({
     mimeData: new MimeData(),
     dragImage: target,
@@ -73,7 +75,7 @@ export class BoundedDrag extends Drag {
     this.moveDragImage;
   }
   moveDragImage(clientX: number, clientY: number): void {
-    // see if we lack a drag image or if drag image is udpdate-less
+    // see if we lack a drag image or if drag image is update-less
     if (!this.dragImage) {
       return;
     }


### PR DESCRIPTION
# Shadow/line fixes when moving + handler.ts refactoring

### Issue being fixed:
Fixes #138 

### Changes proposed:
- Fixed some comments in `selection.ts`
- Added comments to other `handler.ts` functions
- Added `computeGridBoundingRegion` to refactor common code that was being used in two places
- Added restrictions to prevent the moving line from going outside of the viewport
- Modified `selectionIndex` to correctly represent the index of the destination row/column