### PR TITLE
Selection UX (Insert Below/Right/Moving with Undo/Redo)

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -9,6 +9,7 @@ import { Drag } from '@lumino/dragdrop';
 import { Signal } from '@lumino/signaling';
 import { renderSelection, IBoundingRegion, BoundedDrag } from './selection';
 import { EditorModel } from './newmodel';
+import { DSVEditor } from './widget';
 
 export class RichMouseHandler extends BasicMouseHandler {
   private _moveLine: BoundedDrag;
@@ -386,11 +387,14 @@ export class RichMouseHandler extends BasicMouseHandler {
 
       // we can assume there is a selection as it is necessary to move rows/columns
       const { r1, r2, c1, c2 } = selectionModel.currentSelection();
+      const update: DSVEditor.ModelChangedArgs = {
+        selection: { r1, r2, c1, c2 }
+      };
 
       if (this._moveData.region === 'column-header') {
         const startColumn = this._moveData.column;
         const endColumn = this._selectionIndex;
-        model.moveColumns('body', startColumn, endColumn, 1);
+        model.moveColumns('body', startColumn, endColumn, 1, update);
         // select the row that was just moved
         selectionModel.select({
           r1,
@@ -404,7 +408,7 @@ export class RichMouseHandler extends BasicMouseHandler {
       } else if (this._moveData.region === 'row-header') {
         const startRow = this._moveData.row;
         const endRow = this._selectionIndex;
-        model.moveRows('body', startRow, endRow, 1);
+        model.moveRows('body', startRow, endRow, 1, update);
 
         // select the row that was just moved
         selectionModel.select({

--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -604,7 +604,8 @@ export class EditorModel extends MutableDataModel {
     region: DataModel.CellRegion,
     start: number,
     end: number,
-    span: number
+    span: number,
+    update: DSVEditor.ModelChangedArgs
   ): DSVEditor.ModelChangedArgs {
     // Start and end come to us as an index on a particular region. We need the
     // absolute index (ie index 0 is the first row of data).
@@ -615,9 +616,6 @@ export class EditorModel extends MutableDataModel {
     if (start === end) {
       return;
     }
-
-    // Set up an udate object for the litestore.
-    const update: DSVEditor.ModelChangedArgs = {};
 
     // Unpack values from the litestore.
     const { rowMap, columnMap } = this._litestore.getRecord({
@@ -716,15 +714,13 @@ export class EditorModel extends MutableDataModel {
     region: DataModel.CellRegion,
     start: number,
     end: number,
-    span: number
+    span: number,
+    update: DSVEditor.ModelChangedArgs
   ): DSVEditor.ModelChangedArgs {
     // bail early if we are moving no distance
     if (start === end) {
       return;
     }
-
-    // Set up an udate object for the litestore.
-    const update: DSVEditor.ModelChangedArgs = {};
 
     // Unpack values from the litestore.
     const { columnMap, rowMap } = this._litestore.getRecord({

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -389,8 +389,7 @@ export class DSVEditor extends Widget {
    * Called every time the datamodel updates
    * Updates the file and the litestore
    * @param emitter
-   * @param data The raw data used to update the model
-   * @param change The arguments from the datamodel change used ot update the Litestore
+   * @param args The row, column, value, record update, selection model
    */
   private _updateModel(
     emitter: EditorModel,

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -395,6 +395,11 @@ export class DSVEditor extends Widget {
     emitter: EditorModel,
     args: DSVEditor.ModelChangedArgs
   ): void {
+    // if not selection was passed through, take the current selection
+    if (!args.selection) {
+      args.selection = this._grid.selectionModel.currentSelection();
+    }
+
     this._litestore.beginTransaction();
     this.updateLitestore(args);
     this._litestore.endTransaction();
@@ -442,7 +447,6 @@ export class DSVEditor extends Widget {
     };
     // Set up the update object for the litestore.
     let update: DSVEditor.ModelChangedArgs | null = null;
-
     switch (type) {
       case 'insert-row-above': {
         update = this.dataModel.addRows(this._region, this._row);

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -431,6 +431,16 @@ export class DSVEditor extends Widget {
       c1 = Math.min(selection.c1, selection.c2);
       c2 = Math.max(selection.c1, selection.c2);
     }
+
+    const newSelection: SelectionModel.SelectArgs = {
+      r1,
+      r2,
+      c1,
+      c2,
+      cursorColumn: c1,
+      cursorRow: r1,
+      clear: 'all'
+    };
     // Set up the update object for the litestore.
     let update: DSVEditor.ModelChangedArgs | null = null;
 
@@ -443,24 +453,14 @@ export class DSVEditor extends Widget {
         break;
       }
       case 'insert-row-below': {
-        if (!selection) {
-          break;
-        }
         update = this.dataModel.addRows(this._region, this._row + 1);
 
         // Add the type property so that we can differentiate insert above insert below.
         update.type = type;
 
         // move the selection down a row to account for the new row being inserted
-        selectionModel.select({
-          r1: r1 + 1,
-          r2: r2 + 1,
-          c1,
-          c2,
-          cursorRow: r1,
-          cursorColumn: c1,
-          clear: 'all'
-        });
+        newSelection.r1 += 1;
+        newSelection.r2 += 1;
         break;
       }
       case 'insert-column-left': {
@@ -471,22 +471,12 @@ export class DSVEditor extends Widget {
         break;
       }
       case 'insert-column-right': {
-        // Bail early if no selection was made.
-        if (!selection) {
-          break;
-        }
         update = this.dataModel.addColumns(this._region, this._column + 1);
+        update.type = type;
 
-        // move the selection down a row to account for the new column being inserted
-        selectionModel.select({
-          r1,
-          r2,
-          c1: c1 + 1,
-          c2: c2 + 1,
-          cursorRow: r1,
-          cursorColumn: c1,
-          clear: 'all'
-        });
+        // move the selection right a column to account for the new column being inserted
+        newSelection.c1 += 1;
+        newSelection.c2 += 1;
         break;
       }
       case 'remove-row': {
@@ -541,6 +531,11 @@ export class DSVEditor extends Widget {
           record: DSVEditor.RECORD_ID
         });
 
+        this._litestore.undo();
+
+        // Have the model emit the opposite change to the Grid.
+        this.dataModel.emitOppositeChange(gridChange);
+
         // reselect the previous selection.
         const { r1, r2, c1, c2 } = selection;
         this._grid.selectionModel.select({
@@ -552,10 +547,6 @@ export class DSVEditor extends Widget {
           cursorColumn: c1,
           clear: 'all'
         });
-        this._litestore.undo();
-
-        // Have the model emit the opposite change to the Grid.
-        this.dataModel.emitOppositeChange(gridChange);
 
         break;
       }
@@ -607,9 +598,11 @@ export class DSVEditor extends Widget {
         break;
     }
     if (update) {
+      update.selection = selection;
       this._litestore.beginTransaction();
       this.updateLitestore(update);
       this._litestore.endTransaction();
+      this._grid.selectionModel.select(newSelection);
     }
   }
 
@@ -619,7 +612,7 @@ export class DSVEditor extends Widget {
    * @param change The change args for the Datagrid (may be null)
    */
   public updateLitestore(update?: DSVEditor.ModelChangedArgs): void {
-    const selection = this._grid.selectionModel.currentSelection();
+    //const selection = this._grid.selectionModel.currentSelection();
     this._litestore.updateRecord(
       {
         schema: DSVEditor.DATAMODEL_SCHEMA,
@@ -632,7 +625,7 @@ export class DSVEditor extends Widget {
         gridChange: update.gridUpdate || null,
         gridChangeRecord:
           update.gridChangeRecordUpdate || DSVEditor.NULL_CHANGE_SPLICE,
-        selection: selection,
+        selection: update.selection || null,
         type: update.type
       }
     );
@@ -668,6 +661,7 @@ export class DSVEditor extends Widget {
     super.onAfterAttach(msg);
     this.node.addEventListener('paste', this._handlePaste.bind(this));
   }
+
   private _handlePaste(event: ClipboardEvent): void {
     const copiedText: string = event.clipboardData.getData('text/plain');
     // prevent default behavior
@@ -746,8 +740,8 @@ export namespace DSVEditor {
    * The types of mutations that can be made to the model.
    */
   export type ModelChangeType =
-    | 'insert-rows-right'
-    | 'insert-rows-left'
+    | 'insert-rows-above'
+    | 'insert-rows-below'
     | 'insert-columns-right'
     | 'insert-columns-left'
     | 'remove-rows'
@@ -767,6 +761,7 @@ export namespace DSVEditor {
     gridUpdate?: DataModel.ChangedArgs;
     gridChangeRecordUpdate?: ListField.Update<GridChangeRecordArgs>;
     type?: string;
+    selection?: SelectionModel.Selection;
   };
 
   export const SCHEMA_ID = 'datamodel';

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -535,6 +535,10 @@ export class DSVEditor extends Widget {
         // Have the model emit the opposite change to the Grid.
         this.dataModel.emitOppositeChange(gridChange);
 
+        if (!selection) {
+          break;
+        }
+
         // reselect the previous selection.
         const { r1, r2, c1, c2 } = selection;
         this._grid.selectionModel.select({
@@ -562,6 +566,13 @@ export class DSVEditor extends Widget {
           record: DSVEditor.RECORD_ID
         });
 
+        // Have the data model emit the grid change to the grid.
+        this.dataModel.emitCurrentChange(gridChange);
+
+        if (!selection) {
+          break;
+        }
+
         let { r1, r2, c1, c2 } = selection;
         // handle special cases for selection
         if (type === 'insert-row-below') {
@@ -588,8 +599,6 @@ export class DSVEditor extends Widget {
           cursorColumn: c1,
           clear: 'all'
         });
-        // Have the data model emit the grid change to the grid.
-        this.dataModel.emitCurrentChange(gridChange);
         break;
       }
       case 'save':


### PR DESCRIPTION
# Selection UX (Insert Below/Right/Moving with Undo/Redo)

### Issue being fixed:
N/A

### Changes proposed:
- Insert below/right selects the row/column that was inserted (undo selects row/column that the insert was made from)
- Moving rows/columns selects the destination (undo selects the original)
