### PR TITLE
Save keybinding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -408,6 +408,13 @@ function addCommands(
   });
 
   app.commands.addKeyBinding({
+    command: CommandIDs.save,
+    args: {},
+    keys: ['Accel S'],
+    selector: GLOBAL_SELECTOR
+  });
+
+  app.commands.addKeyBinding({
     command: CommandIDs.cutContextMenu,
     args: {},
     keys: ['Accel X'],


### PR DESCRIPTION
# Save keybinding

### Issue being fixed:
N/A

### Changes proposed:
- Save is now has the keybinding `Accel S` calling our serialize and save methods instead of the `docmanager:save`
