### PR TITLE
Unsaved changes dialog

### DIFF
--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -1,0 +1,21 @@
+import { Dialog } from '@jupyterlab/apputils';
+import { DSVEditor } from './widget';
+
+export function unsaveDialog(widget: DSVEditor): Dialog<unknown> {
+  const path = widget.context.path;
+  const n = path.lastIndexOf('/');
+  const fileName = path.substring(n + 1);
+
+  const dialog = new Dialog({
+    title: 'Save Your Changes?',
+    body: `Your changes to "${fileName}" will be lost if you don't save them.`,
+    buttons: [
+      Dialog.warnButton({ label: "Don't Save" }),
+      Dialog.cancelButton(),
+      Dialog.okButton({
+        label: 'Save'
+      })
+    ]
+  });
+  return dialog;
+}

--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -1465,10 +1465,11 @@ export class EditorModel extends MutableDataModel {
     };
 
     // Get a snapshot of the current state of the grid.
-    const gridState = {
+    const gridState: DSVEditor.GridState = {
       currentRows,
       currentColumns,
-      nextChange
+      nextChange,
+      nextCommand: 'init'
     };
 
     update.gridStateUpdate = gridState;


### PR DESCRIPTION
# Unsaved changes dialog

### Issue being fixed:
Fixes #165 

### Changes proposed:
- New `dialog.ts` file containing the dialog
- New `dirty` attribute on the `DSVEditor` that is true when there are unsaved changes
- Added functionality to `dispose()` method in `EditableCSVDocumentWidget` to prompt save dialog and take the correct steps accordingly
