### PR TITLE
Paste bug fix/cut cells refactor

### DIFF
--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -983,8 +983,6 @@ export class EditorModel extends MutableDataModel {
    * Cut a selection of cells.
    * NOTE: this method both copies the cells to the _clipboard property and clears them
    * from the region.
-   *
-   * TODO: refactor so that cut uses the already existing method clearCells.
    */
   cut(
     region: DataModel.CellRegion,
@@ -993,32 +991,14 @@ export class EditorModel extends MutableDataModel {
     endRow: number,
     endColumn: number
   ): DSVEditor.ModelChangedArgs {
-    // Set up the update object for the litestore.
-    const update: DSVEditor.ModelChangedArgs = {};
-    // we use the value map to redefine values within the cut as ''. Need to map
-    // to the static values.
-    // copy the values
     this.copy('body', startRow, startColumn, endRow, endColumn);
-    const rowSpan = Math.abs(startRow - endRow) + 1;
-    const columnSpan = Math.abs(startColumn - endColumn) + 1;
 
-    // Fill in the new blank values.
-    const values = new Array(rowSpan)
-      .fill('')
-      .map(elem => new Array(columnSpan).fill(''));
-
-    // set the new data.
-    this.setData(
-      'body',
-      startRow,
-      startColumn,
-      values,
-      rowSpan,
-      columnSpan,
-      update
-    );
-
-    return update;
+    return this.clearCells('body', {
+      r1: startRow,
+      r2: endRow,
+      c1: startColumn,
+      c2: endColumn
+    });
   }
 
   /**

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -644,14 +644,15 @@ export class DSVEditor extends Widget {
 
   /**
    * Updates the current transaction with the raw data, header, and changeArgs
-   * Requires Litestore.beginTransaction() to be called before and Litestore.endTransaction to be called after
    * @param update The modelChanged args for the Datagrid (may be null)
    */
   public updateModel(update?: DSVEditor.ModelChangedArgs): void {
-    // for every litestore change except the init, set the dirty boolean to true
+    // grab current selection if none exists
     if (!update.selection) {
       update.selection = this._grid.selectionModel.currentSelection();
     }
+
+    // for every litestore change except the init, set the dirty boolean to true
     this.dirty =
       update &&
       update.gridStateUpdate &&
@@ -718,9 +719,7 @@ export class DSVEditor extends Widget {
     const column = Math.min(c1, c2);
     const update = this.dataModel.paste(this._region, row, column, copiedText);
     this._cancelEditing();
-    this.litestore.beginTransaction();
     this.updateModel(update);
-    this.litestore.endTransaction();
   }
 
   private _cancelEditing(): void {


### PR DESCRIPTION
# Paste bug fix/cut cells refactor

### Issue being fixed:
N/A

### Changes proposed:
- Paste function was trying to create two `Litestore` `Transactions` resulting in an error
- Refactored `cut` method to use the `clearCells` method 
