### PR TITLE
WCAG AAA approved search match colors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -515,8 +515,8 @@ namespace Private {
    */
   export const DARK_TEXT_CONFIG: TextRenderConfig = {
     textColor: '#F5F5F5',
-    matchBackgroundColor: '#F99C3D',
-    currentMatchBackgroundColor: '#F57C00',
+    matchBackgroundColor: 'rgba(0, 84, 168, 0.5)',
+    currentMatchBackgroundColor: '#0055AA',
     horizontalAlignment: 'center'
   };
 }


### PR DESCRIPTION
# Description of the Pull Request
White text on an orange background does not pass the web content accessibility guidelines. So I changed the search match colors for the dark mode to an accessible blue color. The color is from the design system. 

### Issue being fixed:
None

### Changes proposed:
- search match colors are changed from an orange to a blue
