### PR TITLE
Inserting/removing column bug fixes + refactor

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -480,7 +480,7 @@ export class RichMouseHandler extends BasicMouseHandler {
   /**
    * Handles a double click event
    */
-  onMouseDoubleClick(grid: DataGrid, event: MouseEvent) {
+  onMouseDoubleClick(grid: DataGrid, event: MouseEvent): void {
     const { region, row, column } = grid.hitTest(event.clientX, event.clientY);
     if (region === 'column-header') {
       if (grid.editable) {
@@ -515,7 +515,7 @@ export class RichMouseHandler extends BasicMouseHandler {
         const editor = new HeaderCellEditor();
 
         // Begin editing the cell.
-        grid.editorController!.edit(cell, { editor, onCommit });
+        grid.editorController.edit(cell, { editor, onCommit });
       }
     }
     super.onMouseDoubleClick(grid, event);

--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -1639,6 +1639,11 @@ export class EditorModel extends MutableDataModel {
       return elem[0] < rowMap.length && elem[1] < columnMap.length;
     });
 
+    // Bail early if the keys are empty. This can happen if you insert and remove the same column
+    if (keys.length === 0) {
+      return this._model.rawData;
+    }
+
     // Now revert the keys to their corresponding map keys.
     const valueKeys = keys.map(key => `${rowMap[key[0]]},${columnMap[key[1]]}`);
 

--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -366,7 +366,7 @@ export class EditorModel extends MutableDataModel {
     const values = [];
     let i = 0;
     while (i < span) {
-      values.push(-(this.totalRows() + this._rowsRemoved));
+      values.push(-(this.totalRows + this._rowsRemoved));
       i++;
       this._rowsAdded++;
     }
@@ -432,7 +432,7 @@ export class EditorModel extends MutableDataModel {
     let i = 0;
     let nextKey: number;
     while (i < span) {
-      nextKey = -(this.totalColumns() + this._columnsRemoved);
+      nextKey = -(this.totalColumns + this._columnsRemoved);
       values.push(nextKey);
       columnHeaders[`0,${nextKey}`] = `Column ${start + i + 1}`;
       i++;
@@ -855,7 +855,7 @@ export class EditorModel extends MutableDataModel {
     const values = [];
     let i = 0;
     while (i < span) {
-      values.push(-(this.totalRows() + this._rowsRemoved));
+      values.push(-(this.totalRows + this._rowsRemoved));
       i++;
       this._rowsAdded++;
     }
@@ -930,7 +930,7 @@ export class EditorModel extends MutableDataModel {
     const values = [];
     let i = 0;
     while (i < span) {
-      values.push(-(this.totalColumns() + this._columnsAdded));
+      values.push(-(this.totalColumns + this._columnsAdded));
       i++;
       this._columnsAdded++;
     }
@@ -1050,8 +1050,8 @@ export class EditorModel extends MutableDataModel {
     row = this._absoluteIndex(row, region);
 
     // see how much space we have
-    const rowsBelow = this.totalRows() - row;
-    const columnsRight = this.totalColumns() - column;
+    const rowsBelow = this.totalRows - row;
+    const columnsRight = this.totalColumns - column;
 
     // clamp the values we are adding at the bounds of the grid
     const rowSpan = Math.min(rowsBelow, this._clipboard.length);

--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -1369,7 +1369,7 @@ export class EditorModel extends MutableDataModel {
   /**
    * translate from the Grid's row IDs to our own standard
    */
-  private _absoluteIndex(row: number, region: DataModel.CellRegion) {
+  private _absoluteIndex(row: number, region: DataModel.CellRegion): number {
     return region === 'column-header' || region === 'corner-header'
       ? 0
       : row + 1;
@@ -1378,7 +1378,7 @@ export class EditorModel extends MutableDataModel {
   /**
    * translate from our unique row ID to the Grid's standard
    */
-  private _regionIndex(row: number, region: DataModel.CellRegion) {
+  private _regionIndex(row: number, region: DataModel.CellRegion): number {
     return region === 'column-header' ? 0 : row - 1;
   }
 
@@ -1408,7 +1408,7 @@ export class EditorModel extends MutableDataModel {
   /**
    * Adds new rows coming in from the asynchronous parsing of string by the DSVModel.
    */
-  private _assimilateNewRows(start: number, span: number) {
+  private _assimilateNewRows(start: number, span: number): void {
     // Set up an udate object for the litestore.
     const update: DSVEditor.ModelChangedArgs = {};
 
@@ -1554,7 +1554,7 @@ export class EditorModel extends MutableDataModel {
     const mapArray: Array<string | 0> = new Array(rowMap.length).fill(0);
     const { buffers, slices } = slicePattern;
     // initialize a callback for the map method.
-    const mapper = (elem: any, index: number) => {
+    const mapper = (elem: any, index: number): string => {
       const row = rowMap[index];
       if (row < 0) {
         return this._blankRow(columnMap);
@@ -1655,7 +1655,7 @@ export class EditorModel extends MutableDataModel {
     const dl = this.model.delimiter.length;
 
     // Create the map function.
-    const mapper = (elem: any, index: number) => {
+    const mapper = (elem: any, index: number): string => {
       let sliceStart: number;
       const startKey = keys[index];
       const endKey = keys[index + 1];

--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -1505,6 +1505,12 @@ export class EditorModel extends MutableDataModel {
     );
   }
 
+  /**
+   * Builds the slicing pattern that needs to be applied to every row in the model
+   * @param columnMap
+   * @param model
+   * @returns The SlicePattern containing a list of buffers (arrays of delimiters) and slices (indexes to slice the original string on)
+   */
   private _columnSlicePattern(
     columnMap: ListField.Value<number>,
     model: DSVModel
@@ -1515,12 +1521,21 @@ export class EditorModel extends MutableDataModel {
     let nextSlice: number[] = [];
     let delimiterReps = 0;
     while (i < columnMap.length) {
+      // add another delimeter and move to the next index if the value is negative (new column)
       while (columnMap[i] < 0) {
         i++;
         delimiterReps++;
       }
+
+      // remove a delimiter of the last column is involved
+      if (i === columnMap.length) {
+        delimiterReps--;
+      }
+
       buffers.push(model.delimiter.repeat(delimiterReps));
       delimiterReps = 0;
+
+      // break if we reached the end of the column map
       if (i >= columnMap.length) {
         break;
       }

--- a/src/newmodel.ts
+++ b/src/newmodel.ts
@@ -97,7 +97,7 @@ export class EditorModel extends MutableDataModel {
   /**
    * The grid's current number of rows. TOTAL, NOT BY REGION.
    */
-  totalRows(): number {
+  get totalRows(): number {
     return (
       this._model.rowCount('body') + this._rowsAdded - this._rowsRemoved + 1
     );
@@ -109,7 +109,7 @@ export class EditorModel extends MutableDataModel {
    * Notes: This is equivalent to columnCount('body')
    */
 
-  totalColumns(): number {
+  get totalColumns(): number {
     return (
       this._model.columnCount('body') +
       this._columnsAdded -

--- a/src/searchservice.ts
+++ b/src/searchservice.ts
@@ -50,7 +50,7 @@ export class GridSearchService {
   cellBackgroundColorRendererFunc(
     config: TextRenderConfig
   ): CellRenderer.ConfigFunc<string> {
-    return ({ value, row, column }) => {
+    return ({ value, row, column }): string => {
       if (this._query) {
         if ((value as string).match(this._query)) {
           if (

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -369,12 +369,12 @@ export class DSVEditor extends Widget {
       const rowUpdate = {
         index: 0,
         remove: 0,
-        values: toArray(range(0, this.dataModel.totalRows()))
+        values: toArray(range(0, this.dataModel.totalRows))
       };
       const columnUpdate = {
         index: 0,
         remove: 0,
-        values: toArray(range(0, this.dataModel.totalColumns()))
+        values: toArray(range(0, this.dataModel.totalColumns))
       };
 
       // Add the map updates to the update object.

--- a/test/newmodel.spec.ts
+++ b/test/newmodel.spec.ts
@@ -43,12 +43,12 @@ beforeEach(() => {
   const rowUpdate = {
     index: 0,
     remove: 0,
-    values: toArray(range(0, model.totalRows()))
+    values: toArray(range(0, model.totalRows))
   };
   const columnUpdate = {
     index: 0,
     remove: 0,
-    values: toArray(range(0, model.totalColumns()))
+    values: toArray(range(0, model.totalColumns))
   };
 
   // Add the map updates to the update object.


### PR DESCRIPTION
# Inserting/removing column bug fixes

### Issue being fixed:
Fixes #194 
Fixes #195 

### Bugs Fixed:
- Inserting in the last column now doesn't add the extra comma
   - Required an extra check in `_columnSlicePattern()`
- Removing the same row that was inserted now saves correctly
   - Required an extra check in `_performMicroSlice()`

### Changes Proposed:
- Removed `model` as a parameter from several functions
- Changed `totalRows`/`totalColumns` to getters in order to access them without the `()`
- Added return types to various functions