### PR TITLE
Ghost row/column only for left clicks

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -811,9 +811,18 @@ export class DSVEditor extends Widget {
    * Updates the context menu elements.
    */
   private _updateContextElements(): void {
+    // calculate dimensions for the ghost row/column
+    const ghostRow = this._grid.rowSize(
+      'body',
+      this._grid.rowCount('body') - 1
+    );
+    const ghostColumn = this._grid.columnSize(
+      'body',
+      this._grid.columnCount('body') - 1
+    );
     // Update the column header, row header, and background elements.
-    this._background.style.width = `${this._grid.bodyWidth}px`;
-    this._background.style.height = `${this._grid.bodyHeight}px`;
+    this._background.style.width = `${this._grid.bodyWidth - ghostColumn}px`;
+    this._background.style.height = `${this._grid.bodyHeight - ghostRow}px`;
     this._background.style.left = `${this._grid.headerWidth}px`;
     this._background.style.top = `${this._grid.headerHeight}px`;
     this._columnHeader.style.left = `${this._grid.headerWidth}px`;


### PR DESCRIPTION
# Ghost row/column only for left clicks

### Issue being fixed:
Fixes #212 

### Changes proposed:
- Renamed `_lastHoverRegion` to `_currentHoverRegion` for clarity
- Fixed `onMouseHover()` to set `hoverRegion` to `null` if neither the ghost row/column is being hovered
    - Prior to this, you could click anywhere to the right of the grid if you last hovered over a column to add it
- Fixed and refactored `onMouseDown()` to do some additional checks before adding the ghost row/column 