### PR TITLE
Right-click column header results in move shadow

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -204,7 +204,7 @@ export class RichMouseHandler extends BasicMouseHandler {
       return;
     }
     super.onMouseDown(grid, event);
-    if (this._cursor === 'grab') {
+    if (event.type === 'mousedown' && this._cursor === 'grab') {
       this._cursor = 'grabbing';
       this.handleGrabbing();
     }


### PR DESCRIPTION
# Right-click column header results in move shadow

### Issue being fixed:
Fixes #271 

### Changes proposed:
- Added an extra check to only run "move" commands if the event was a `mousedown` (left-click)
