### PR TITLE
Fixes small bug with data types not updating on an undo/redo that changes the type.

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -734,13 +734,7 @@ export class DSVEditor extends Widget {
    * @param update The modelChanged args for the Datagrid (may be null)
    */
   public updateModel(update?: DSVEditor.ModelChangedArgs): void {
-    // if not selection was passed through, take the current selection
-    // Bail early if there is no update.
-    if (!update) {
-      return;
-    }
     // If no selection property was passed in, record the current selection.
-    // grab current selection if none exists
     if (!update.selection) {
       update.selection = this._grid.selectionModel.currentSelection();
     }
@@ -751,21 +745,24 @@ export class DSVEditor extends Widget {
       update.gridStateUpdate.nextCommand === 'init'
         ? false
         : true;
-    // Update the litestore.
-    this._litestore.beginTransaction();
-    this._litestore.updateRecord(
-      {
-        schema: DSVEditor.DATAMODEL_SCHEMA,
-        record: DSVEditor.RECORD_ID
-      },
-      {
-        rowMap: update.rowUpdate || DSVEditor.NULL_NUM_SPLICE,
-        columnMap: update.columnUpdate || DSVEditor.NULL_NUM_SPLICE,
-        valueMap: update.valueUpdate || null,
-        selection: update.selection || null,
-        gridState: update.gridStateUpdate || null
-      }
-    );
+    if (update) {
+      // Update the litestore.
+      this._litestore.beginTransaction();
+      this._litestore.updateRecord(
+        {
+          schema: DSVEditor.DATAMODEL_SCHEMA,
+          record: DSVEditor.RECORD_ID
+        },
+        {
+          rowMap: update.rowUpdate || DSVEditor.NULL_NUM_SPLICE,
+          columnMap: update.columnUpdate || DSVEditor.NULL_NUM_SPLICE,
+          valueMap: update.valueUpdate || null,
+          selection: update.selection || null,
+          gridState: update.gridStateUpdate || null
+        }
+      );
+    }
+
     if (this.dataModel.isDataFormatted) {
       this._updateRenderer();
     }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -764,10 +764,6 @@ export class DSVEditor extends Widget {
       this._litestore.endTransaction();
     }
 
-    if (this.dataModel.isDataFormatted) {
-      this._updateRenderer();
-    }
-
     // Recompute all of the metadata.
     // TODO: integrate the metadata with the rest of the model.
     if (this.dataModel.isDataFormatted) {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -734,18 +734,18 @@ export class DSVEditor extends Widget {
    * @param update The modelChanged args for the Datagrid (may be null)
    */
   public updateModel(update?: DSVEditor.ModelChangedArgs): void {
-    // If no selection property was passed in, record the current selection.
-    if (!update.selection) {
-      update.selection = this._grid.selectionModel.currentSelection();
-    }
-    // for every litestore change except the init, set the dirty boolean to true
-    this.dirty =
-      update &&
-      update.gridStateUpdate &&
-      update.gridStateUpdate.nextCommand === 'init'
-        ? false
-        : true;
     if (update) {
+      // If no selection property was passed in, record the current selection.
+      if (!update.selection) {
+        update.selection = this._grid.selectionModel.currentSelection();
+      }
+      // for every litestore change except the init, set the dirty boolean to true
+      this.dirty =
+        update &&
+        update.gridStateUpdate &&
+        update.gridStateUpdate.nextCommand === 'init'
+          ? false
+          : true;
       // Update the litestore.
       this._litestore.beginTransaction();
       this._litestore.updateRecord(
@@ -761,12 +761,12 @@ export class DSVEditor extends Widget {
           gridState: update.gridStateUpdate || null
         }
       );
+      this._litestore.endTransaction();
     }
 
     if (this.dataModel.isDataFormatted) {
       this._updateRenderer();
     }
-    this._litestore.endTransaction();
 
     // Recompute all of the metadata.
     // TODO: integrate the metadata with the rest of the model.

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -724,9 +724,9 @@ export class DSVEditor extends Widget {
       update.selection = selection;
       // Add the command to the grid state.
       update.gridStateUpdate.nextCommand = command;
-      this.updateModel(update);
       this._grid.selectionModel.select(newSelection);
     }
+    this.updateModel(update);
   }
 
   /**


### PR DESCRIPTION
# Description of the Pull Request

Fixes small bug with data types not updating on an undo/redo that changes the type.

### Issue being fixed:
Fixes #279 

### Changes proposed:
- `onCommand` calls `updateModel` even if there is no `update` object. (causing it to be triggered on an undo & a redo)
- Bail statement in `updateModel` replaced with having all the model related stuff be wrapped in an if-statement. This achieves the same thing as the bail statement while letting us update the renderers AFTER we have updated the model.
