### PR TITLE
Created a selectCell method in the PaintedGrid

### DIFF
--- a/src/grid.ts
+++ b/src/grid.ts
@@ -1,4 +1,4 @@
-import { DataGrid } from 'tde-datagrid';
+import { DataGrid, SelectionModel } from 'tde-datagrid';
 import { LabIcon, addIcon } from '@jupyterlab/ui-components';
 import { EditorModel } from './newmodel';
 
@@ -43,6 +43,30 @@ export class PaintedGrid extends DataGrid {
    */
   get ghostColumnWidth(): number {
     return this.defaultSizes.columnWidth;
+  }
+
+  /**
+   * Selects cells using the selection model
+   * @param row The row being selected
+   * @param column The column being selected
+   */
+  selectCells(selection: SelectionModel.Selection): void {
+    // Bail if no selection
+    if (!selection) {
+      return;
+    }
+
+    const { r1, r2, c1, c2 } = selection;
+    const select: SelectionModel.SelectArgs = {
+      r1,
+      r2,
+      c1,
+      c2,
+      cursorRow: r1,
+      cursorColumn: c1,
+      clear: 'all'
+    };
+    this.selectionModel.select(select);
   }
 
   /**

--- a/src/mousehandler.ts
+++ b/src/mousehandler.ts
@@ -158,7 +158,7 @@ export class RichMouseHandler extends BasicMouseHandler {
    * @param grid - The data grid of interest.
    * @param event - The mouse down event of interest.
    */
-  onMouseDown(grid: DataGrid, event: MouseEvent): void {
+  onMouseDown(grid: PaintedGrid, event: MouseEvent): void {
     const model = grid.dataModel as EditorModel;
 
     // if the event was a left click and the hover region isn't null
@@ -183,24 +183,8 @@ export class RichMouseHandler extends BasicMouseHandler {
       update.selection = selection;
       model.onChangedSignal.emit(update);
 
-      // Bail if there's no selection
-      if (!selection) {
-        return;
-      }
-
-      // Unpack the selection args.
-      const { r1, r2, c1, c2 } = selection;
-      // Remake the selection.
-      selectionModel.select({
-        r1,
-        r2,
-        c1,
-        c2,
-        cursorRow: c1,
-        cursorColumn: c2,
-        clear: 'all'
-      });
-
+      // select cells
+      grid.selectCells(selection);
       return;
     }
     super.onMouseDown(grid, event);
@@ -426,7 +410,7 @@ export class RichMouseHandler extends BasicMouseHandler {
    * @param grid
    * @param event
    */
-  onMouseUp(grid: DataGrid, event: MouseEvent): void {
+  onMouseUp(grid: PaintedGrid, event: MouseEvent): void {
     this._event = event;
     const model = grid.dataModel as EditorModel;
     // emit the current mouse position to the Editor
@@ -442,31 +426,16 @@ export class RichMouseHandler extends BasicMouseHandler {
         const startColumn = this._moveData.column;
         const endColumn = this._selectionIndex;
         update = model.moveColumns('body', startColumn, endColumn, 1);
+
         // select the row that was just moved
-        selectionModel.select({
-          r1,
-          r2,
-          c1: endColumn,
-          c2: endColumn,
-          cursorRow: r1,
-          cursorColumn: c1,
-          clear: 'all'
-        });
+        grid.selectCells({ r1, r2, c1: endColumn, c2: endColumn });
       } else if (this._moveData.region === 'row-header') {
         const startRow = this._moveData.row;
         const endRow = this._selectionIndex;
         update = model.moveRows('body', startRow, endRow, 1);
 
         // select the row that was just moved
-        selectionModel.select({
-          r1: endRow,
-          r2: endRow,
-          c1,
-          c2,
-          cursorRow: r1,
-          cursorColumn: c1,
-          clear: 'all'
-        });
+        grid.selectCells({ r1: endRow, r2: endRow, c1, c2 });
       }
       if (update) {
         // Add the selection to the update.
@@ -485,7 +454,7 @@ export class RichMouseHandler extends BasicMouseHandler {
    * @param grid - The data grid of interest.
    * @param event - The context menu event of interest.
    */
-  onContextMenu(grid: DataGrid, event: MouseEvent): void {
+  onContextMenu(grid: PaintedGrid, event: MouseEvent): void {
     const { clientX, clientY } = event;
     const hit = grid.hitTest(clientX, clientY);
     this._mouseUpSignal.emit(hit);

--- a/src/searchprovider.ts
+++ b/src/searchprovider.ts
@@ -185,7 +185,12 @@ export class CSVSearchProvider implements ISearchProvider<CSVDocumentWidget> {
   protected moveToCell(): void {
     if (this._target && this._currentMatch) {
       const { line, column } = this._currentMatch;
-      this._target.content.selectSingleCell(line, column);
+      this._target.content.grid.selectCells({
+        r1: line,
+        r2: line,
+        c1: column,
+        c2: column
+      });
 
       // calculate the offsets and then scroll to that cell
       const rowOffset = this._target.content.grid.rowOffset('body', line);

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -546,15 +546,6 @@ export class DSVEditor extends Widget {
       c2 = Math.max(selection.c1, selection.c2);
     }
 
-    const newSelection: SelectionModel.SelectArgs = {
-      r1,
-      r2,
-      c1,
-      c2,
-      cursorColumn: c1,
-      cursorRow: r1,
-      clear: 'all'
-    };
     // Set up the update object for the litestore.
     let update: DSVEditor.ModelChangedArgs | null = null;
 
@@ -567,8 +558,8 @@ export class DSVEditor extends Widget {
         update = this.dataModel.addRows('body', r2 + 1, rowSpan);
 
         // move the selection down a row to account for the new row being inserted
-        newSelection.r1 += rowSpan;
-        newSelection.r2 += rowSpan;
+        r1 += rowSpan;
+        r2 += rowSpan;
         break;
       }
       case 'insert-columns-left': {
@@ -579,8 +570,8 @@ export class DSVEditor extends Widget {
         update = this.dataModel.addColumns('body', c2 + 1, colSpan);
 
         // move the selection right a column to account for the new column being inserted
-        newSelection.c1 += colSpan;
-        newSelection.c2 += colSpan;
+        c1 += colSpan;
+        c2 += colSpan;
         break;
       }
       case 'remove-rows': {
@@ -645,21 +636,7 @@ export class DSVEditor extends Widget {
         // Have the model emit the opposite change to the Grid.
         this.dataModel.emitOppositeChange(gridState);
 
-        if (!selection) {
-          break;
-        }
-
-        // reselect the previous selection.
-        const { r1, r2, c1, c2 } = selection;
-        this._grid.selectionModel.select({
-          r1,
-          r2,
-          c1,
-          c2,
-          cursorRow: r1,
-          cursorColumn: c1,
-          clear: 'all'
-        });
+        this._grid.selectCells(selection);
 
         break;
       }
@@ -705,15 +682,7 @@ export class DSVEditor extends Widget {
         }
 
         // Make the new selection.
-        this._grid.selectionModel.select({
-          r1,
-          r2,
-          c1,
-          c2,
-          cursorRow: r1,
-          cursorColumn: c1,
-          clear: 'all'
-        });
+        this._grid.selectCells({ r1, r2, c1, c2 });
         break;
       }
       case 'save':
@@ -724,7 +693,7 @@ export class DSVEditor extends Widget {
       update.selection = selection;
       // Add the command to the grid state.
       update.gridStateUpdate.nextCommand = command;
-      this._grid.selectionModel.select(newSelection);
+      this._grid.selectCells({ r1, r2, c1, c2 });
     }
     this.updateModel(update);
   }
@@ -770,24 +739,6 @@ export class DSVEditor extends Widget {
       this.dataModel.dataTypes = this.dataModel.resetMetadata();
       this._updateRenderer();
     }
-  }
-
-  /**
-   * Selects a certain cell using the selection model
-   * @param row The row being selected
-   * @param column The column being selected
-   */
-  public selectSingleCell(row: number, column: number): void {
-    const select: SelectionModel.SelectArgs = {
-      r1: row,
-      r2: row,
-      c1: column,
-      c2: column,
-      cursorRow: row,
-      cursorColumn: column,
-      clear: 'all'
-    };
-    this._grid.selectionModel.select(select);
   }
 
   protected getSelectedRange(): SelectionModel.Selection {


### PR DESCRIPTION
# Created a selectCell method in the PaintedGrid

### Issue being fixed:
N/A

### Changes proposed:
- Since most of our selection differences only involve the rows and columns, creating a `selectCell` method in the `PaintedGrid` class allows us to abstract the selection model when we are trying to select some cells. This can be helpful in the future as if something needs to happen every time cells are selected. You can make this change in one place.
